### PR TITLE
Add J8 header and board name to Zero

### DIFF
--- a/src/PHPi/Board/Zero.php
+++ b/src/PHPi/Board/Zero.php
@@ -13,5 +13,9 @@ use Calcinai\PHPi\Board\Feature;
 class Zero extends Board {
 
     use Feature\SoC\BCM2835;
+    use Feature\Header\J8;
 
+    public static function getBoardName() {
+        return 'Zero';
+    }
 }


### PR DESCRIPTION
In addition to the mapping inside the factory we need some more
changes to use the zero.
